### PR TITLE
chore(counter): empêche les erreurs liées au crawl des pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,23 @@ class Redis extends \Phalcon\Cache\Backend\Redis {
                     'home_test_B' => 'some other thing',
                 ],
                 'chooser' => [\ABTesting\Chooser\PercentChooser::class]
-            ]
+            ],
+            'home_link_url' => [
+                'default' => 'https://www.google.com',
+                'variants' => [
+                    'home_test_A' => 'https://www.google.fr',
+                    'home_test_B' => 'https://www.google.be',
+                ],
+                'chooser' => [\ABTesting\Chooser\PercentChooser::class]
+            ],
+            'home_partial' => [
+                'default' => 'path/to/default',
+                'variants' => [
+                    'home_test_A' => 'path/to/A',
+                    'home_test_B' => 'path/to/B',
+                ],
+                'chooser' => [\ABTesting\Chooser\PercentChooser::class]
+            ],
         ],
     
     ]);
@@ -138,11 +154,55 @@ class Redis extends \Phalcon\Cache\Backend\Redis {
     
 4. Déclarer les actions soumises aux tests A/B avec l'annotation `@AbTesting('home_text_content')`
 
-5. Utiliser les fonctions volt pour afficher les élements souhaités
-
-    ```twig
-    <a href="{{ ab_test_click('home_text_content', 'https://www.google.com') }}">{{ ab_test_result('home_text_content') }}</a>
-    ```
+5. Utiliser les fonctions volt pour afficher les élements souhaités, par exemple :
+   - pour tester un wording :
+   
+      ```twig
+      <a {{ ab_test_href('home_text_content', 'https://www.google.com') }}>
+          {{ ab_test_result('home_text_content') }}
+      </a>
+      ```
+   - pour tester un lien défini comme test :
+   
+      ```twig
+      <a {{ ab_test_href('home_link_url', ab_test_result('home_link_url')) }}>
+          Lien
+      </a>
+      ```
+   - pour tester 2 formats :
+   
+      ```twig
+      {# home.volt #}
+      
+      {{ partial('path/to/specific/partial/dir/' ~ ab_test_result('home_partial')) }}
+      ```
+   
+      ```twig
+      {# path/to/specific/partial/dir/path/to/A.volt #}
+      
+      <!-- your content -->
+      <a {{ ab_test_href('home_partial', 'https://example.org/link/for/A') }}>
+          Lien
+      </a>
+      ```
+   
+      ```twig
+      {# path/to/specific/partial/dir/path/to/B.volt #}
+      
+      <!-- your content -->
+      <a {{ ab_test_href('home_partial', 'https://example.org/link/for/B') }}>
+          Lien
+      </a>
+      ```
+   
+      ```twig
+      {# path/to/specific/partial/dir/path/to/default.volt #}
+      
+      <!-- your content -->
+      <a href="https://example.org">
+          Lien
+      </a>
+      ```
    
 ## Configuration des tests A/B
 

--- a/src/Volt/ABTestingExtension.php
+++ b/src/Volt/ABTestingExtension.php
@@ -3,6 +3,7 @@
 namespace ABTesting\Volt;
 
 use ABTesting\Engine;
+use ABTesting\Exception\AbTestingException;
 use Phalcon\Di;
 use Phalcon\Di\Injectable;
 
@@ -15,6 +16,8 @@ class ABTestingExtension
                 return self::class . '::getTestResult(' . $arguments . ')';
             case 'ab_test_click':
                 return self::class . '::getTestClick(' . $arguments . ')';
+            case 'ab_test_href':
+                return self::class . '::getTestHref(' . $arguments . ')';
         }
 
         return null;
@@ -73,5 +76,14 @@ class ABTestingExtension
         } catch (\Throwable $t) {
             return $target;
         }
+    }
+
+    public static function getTestHref(string $testName, string $target, $winnerName = null)
+    {
+        $counterLink = self::getTestClick($testName, $target, $winnerName);
+        $attributes = 'href="' . htmlspecialchars($target, ENT_QUOTES) . '" ';
+        $attributes .= ' onmousedown="' . htmlspecialchars("this.href = '$counterLink'") . '" ';
+
+        return $attributes;
     }
 }

--- a/src/Volt/ABTestingExtension.php
+++ b/src/Volt/ABTestingExtension.php
@@ -25,8 +25,9 @@ class ABTestingExtension
 
     public static function getTestResult(string $testName): ?string
     {
+        $engine  = Engine::getInstance();
+
         try {
-            $engine  = Engine::getInstance();
             $test = $engine->getTest($testName);
 
             if (!$engine->isActivated()) {
@@ -34,14 +35,20 @@ class ABTestingExtension
             }
             return $test->getWinner()->getValue();
         } catch (\Throwable $t) {
+            if (null !== $engine->getEventsManager()) {
+                $e = new AbTestingException('Unable to get test result.', 0, $t);
+                $engine->getEventsManager()->fire('abtest:beforeException', Engine::getInstance(), $e);
+            }
+
             return null;
         }
     }
 
     public static function getTestClick(string $testName, string $target, $winnerName = null): ?string
     {
+        $engine  = Engine::getInstance();
+
         try {
-            $engine  = Engine::getInstance();
 
             if (!$engine->isActivated()) {
                 return $target;
@@ -74,6 +81,11 @@ class ABTestingExtension
 
             return $path;
         } catch (\Throwable $t) {
+            if (null !== $engine->getEventsManager()) {
+                $e = new AbTestingException('Unable to get test counter url.', 0, $t);
+                $engine->getEventsManager()->fire('abtest:beforeException', Engine::getInstance(), $e);
+            }
+
             return $target;
         }
     }

--- a/tests/Volt/ABTestingExtensionTest.php
+++ b/tests/Volt/ABTestingExtensionTest.php
@@ -8,6 +8,7 @@ use ABTesting\Test\Variant;
 use ABTesting\Tests\TestCase;
 use ABTesting\Volt\ABTestingExtension;
 use Phalcon\Di;
+use Phalcon\Events\Manager as EventsManager;
 use Phalcon\Mvc\Url;
 
 class ABTestingExtensionTest extends TestCase
@@ -57,19 +58,21 @@ class ABTestingExtensionTest extends TestCase
         $engine = $this->createMockForSingleton(Engine::class);
         $engine->expects($this->once())->method('isActivated')->willReturn(false);
         $engine
-            ->expects($this->never())
+            ->expects($this->once())
             ->method('getTest')
             ->with('testName')
             ->willReturn(new Test('testName', [], new Variant('default', 'Default')));
 
-        $this->assertEquals(null, ABTestingExtension::getTestResult('testName'));
+        $this->assertEquals('Default', ABTestingExtension::getTestResult('testName'));
     }
 
 
     public function testGetUndefinedTestResult()
     {
         $engine = $this->createMockForSingleton(Engine::class);
-        $engine->expects($this->once())->method('isActivated')->willReturn(true);
+        $eventsManager = $this->createMock(EventsManager::class);
+        $engine->expects($this->any())->method('getEventsManager')->willReturn($eventsManager);
+        $engine->expects($this->never())->method('isActivated');
         $engine
             ->expects($this->once())
             ->method('getTest')
@@ -263,6 +266,8 @@ class ABTestingExtensionTest extends TestCase
             ->method('get');
 
         $engine = $this->createMockForSingleton(Engine::class);
+        $eventsManager = $this->createMock(EventsManager::class);
+        $engine->expects($this->any())->method('getEventsManager')->willReturn($eventsManager);
         $engine->expects($this->once())->method('isActivated')->willReturn(true);
         $engine
             ->expects($this->once())


### PR DESCRIPTION
# Description

Les bots vont inspecter les liens présents dans la page, ce qui génère des erreurs.

# Spécification technique

- on ajoute une fonction volt `ab_test_href` qui permet de créer les attributs utiles au fonctionnement optimal des `<a>` renvoyant vers le compteur de clics
- on renvoi une erreur 404 quand le lien du compteur de clics ne possède pas l'attibut `u`
- on redirige simplement quand il n'y a pas de referrer dans les headers