### PR TITLE
chore(count): make test countable or not

### DIFF
--- a/src/Chooser/ChooserInterface.php
+++ b/src/Chooser/ChooserInterface.php
@@ -8,4 +8,5 @@ use ABTesting\Test\Variant;
 interface ChooserInterface
 {
     public function choose(Test $test): ?Variant;
+    public function isCountable(Test $test, string $action): bool;
 }

--- a/src/Chooser/PercentChooser.php
+++ b/src/Chooser/PercentChooser.php
@@ -28,4 +28,9 @@ class PercentChooser implements ChooserInterface
 
         return  $test->getVariants()[0] ?? null;
     }
+
+    public function isCountable(Test $test, string $action): bool
+    {
+        return true;
+    }
 }

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -165,20 +165,24 @@ class Engine implements InjectionAwareInterface, EventsAwareInterface
 
     public function savePrint(string $testName, string $template): void
     {
-        if (null !== $this->getEventsManager()) {
-            $this->getEventsManager()->fire('abtest:beforePrint', $this, [$testName, $template]);
-        }
+        if (null !== ($test = $this->getTest($testName)) && $test->getChooser()->isCountable($test, 'print')) {
+            if (null !== $this->getEventsManager()) {
+                $this->getEventsManager()->fire('abtest:beforePrint', $this, [$testName, $template]);
+            }
 
-        $this->counter->saveCounter('print', $this->getDevice(), $testName, $template);
+            $this->counter->saveCounter('print', $this->getDevice(), $testName, $template);
+        }
     }
 
     public function saveClick(string $testName, string $template): void
     {
-        if (null !== $this->getEventsManager()) {
-            $this->getEventsManager()->fire('abtest:beforeClick', $this, [$testName, $template]);
-        }
+        if (null !== ($test = $this->getTest($testName)) && $test->getChooser()->isCountable($test, 'click')) {
+            if (null !== $this->getEventsManager()) {
+                $this->getEventsManager()->fire('abtest:beforeClick', $this, [$testName, $template]);
+            }
 
-        $this->counter->saveCounter('click', $this->getDevice(), $testName, $template);
+            $this->counter->saveCounter('click', $this->getDevice(), $testName, $template);
+        }
     }
 
     /**


### PR DESCRIPTION
# Description

Le but est de pouvoir empêcher le compteur (clic ou vue) de s'incrémenter lors d'un ABTest, utile pour faire de la rétention