### PR TITLE
feat(chooser): ajoute un chooser pour des tests multivariantes

### DIFF
--- a/src/Chooser/MultiplePercentChooser.php
+++ b/src/Chooser/MultiplePercentChooser.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ABTesting\Chooser;
+
+use ABTesting\Test\Test;
+use ABTesting\Test\Variant;
+
+class MultiplePercentChooser implements ChooserInterface
+{
+    /** @var array */
+    private $limits = [];
+
+    /**
+     * PercentChooser constructor.
+     * @param int $floor
+     */
+    public function __construct(array $percents)
+    {
+        foreach ($percents as $idx => $percent) {
+            $range = $idx === 0 ? [0] : array_slice($percents, 0, $idx);
+            $percentMin = array_sum($range);
+            $percentMax = $idx === 0 ? $percent : array_sum($range) + $percent;
+            $this->limits[] = ['min' => $percentMin, 'max' => $percentMax];
+        }
+    }
+
+    public function choose(Test $test): ?Variant
+    {
+        $pull = mt_rand(0, 100);
+        foreach ($this->limits as $idx => $limit) {
+            if ($pull >= $limit['min'] && $pull <= $limit['max']) {
+                return $test->getVariants()[$idx] ?? null;
+            }
+        }
+
+        return  $test->getDefaultVariant();
+    }
+
+    public function isCountable(Test $test, string $action): bool
+    {
+        return true;
+    }
+}

--- a/tests/Chooser/MultiplePercentChooserTest.php
+++ b/tests/Chooser/MultiplePercentChooserTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ABTesting\Tests\Chooser;
+
+use ABTesting\Chooser\MultiplePercentChooser;
+use ABTesting\Test\Test;
+use ABTesting\Test\Variant;
+use PHPUnit\Framework\TestCase;
+
+class MultiplePercentChooserTest extends TestCase
+{
+    public function testChoose()
+    {
+        $chooser = new MultiplePercentChooser([70, 10, 10, 10,], 100);
+        $variantA = new Variant('A', 'A');
+        $variantB = new Variant('B', 'B');
+        $variantC = new Variant('C', 'C');
+        $variantD = new Variant('D', 'D');
+        $variantDefault = new Variant('Default','should never occurs');
+
+        $test = new Test('test', [$variantA, $variantB, $variantC, $variantD], $variantDefault);
+
+        mt_srand(0);
+        $this->assertContains($chooser->choose($test)->getIdentifier(), ['A', 'B', 'C', 'D']);
+        $this->assertFalse($chooser->choose($test)->getIdentifier() === 'Default');
+    }
+}


### PR DESCRIPTION
# Description
On veut faire des tests avec plus de 2 variantes comme celui décrit dans https://lemonde.atlassian.net/browse/WEB-2939 : on a besoin de gerer ce cas

# Spécification technique
un MultiplePercentChooser qui recoit en param du constructeur la répartition désirée entre les différentes variantes et calcule la variante à afficher

# Recette
Verifier sur un test que les différentes variantes sont bien affichée.