### PR TITLE
fix(count): évite de compter les affichages lorsque le test n'a pas abouti

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -92,7 +92,7 @@ class Engine implements InjectionAwareInterface, EventsAwareInterface
             $test = new Test($identifier);
             $defaultVariant = $definition['default'];
             foreach ($definition['variants'] as $key => $variantDefinition) {
-                $variant = new Variant($key, $variantDefinition, (string) $defaultVariant === (string) $key);
+                $variant = new Variant($key, $variantDefinition);
                 $test->addVariant($variant);
             }
             if (empty($test->getDefaultVariant())) {

--- a/src/Volt/ABTestingExtension.php
+++ b/src/Volt/ABTestingExtension.php
@@ -87,7 +87,9 @@ class ABTestingExtension
                 $path = $target;
             }
 
-            $engine->savePrint($test->getIdentifier(), $winner->getIdentifier());
+            if ($path !== $target) {
+                $engine->savePrint($test->getIdentifier(), $winner->getIdentifier());
+            }
 
             return $path;
         } catch (\Throwable $t) {

--- a/tests/Volt/ABTestingExtensionTest.php
+++ b/tests/Volt/ABTestingExtensionTest.php
@@ -260,9 +260,8 @@ class ABTestingExtensionTest extends TestCase
             ->with('testName')
             ->willReturn($test);
         $engine
-            ->expects($this->once())
-            ->method('savePrint')
-            ->with('testName', 'default');
+            ->expects($this->never())
+            ->method('savePrint');
 
         $this->assertEquals('https://www.example.org', ABTestingExtension::getTestClick('testName', 'https://www.example.org'));
     }


### PR DESCRIPTION
# Description

Lorsque le lien de comptage correspond au lien cible c'est que le test n'a pas abouti (variante par défaut, résultat forcé ou la battle ne s'est pas faite).
Or dans ce cas on comptabilise quand même les affichage, ce qui ne sert à rien. Il faut donc éviter de compter ces cas là

# Spécification technique

On englobe le comptage de l'affichage dans une condition pour vérifier que le lien de comptage n'est pas le même que le lien de redirection